### PR TITLE
fix(screenshots.yml): add condition to skip screenshot action if url is empty docs(github-create-repo.md): update image reference to match new screenshot feat(screenshots.json): add new screenshot configuration for 'github-new.png'

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -60,6 +60,7 @@ jobs:
           npm i puppeteer
 
       - name: screenshot
+        if: ${{ matrix.url != '' }}
         uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3
         with:
           run: |

--- a/docs/github-create-repo.md
+++ b/docs/github-create-repo.md
@@ -5,4 +5,4 @@ comments: true
 
 [https://github.com/new](https://github.com/new)
 
-[![https://github.com/new](img/github-create-repo.png)](https://github.com/new)
+[![https://github.com/new](img/github-new.png)](https://github.com/new)

--- a/screenshots.json
+++ b/screenshots.json
@@ -11,6 +11,12 @@
       "filename": "github-fork.png",
       "pointerangle": "45",
       "geometry": "+1000+35"
+    },
+    {
+      "url": "",
+      "filename": "github-new.png",
+      "pointerangle": "45",
+      "geometry": "+1000+35"
     }
   ]
 }


### PR DESCRIPTION
The condition in the screenshot action prevents unnecessary runs when the URL is empty, saving resources. The image reference in the documentation was updated to match the new screenshot, ensuring the correct image is displayed. A new screenshot configuration was added to screenshots.json to support the new 'github-new.png' screenshot, enhancing the visual aid in the documentation.