### PR TITLE
feat: Add Terraform workflow and update related documentation chore: Add creds.json to .gitignore style: Minor formatting change in doit.sh feat: Add backend configuration in terraform.tf

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,238 @@
+---
+name: "terraform"
+
+on: #  yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    paths:
+      - "terraform/**.tf"
+      - terraform/cloud-init/*
+    branches:
+      - "main"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  terraform:
+    name: Terraform Init
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
+    outputs:
+      action: ${{ steps.terraform.outputs.action }}
+    steps:
+      - id: terraform
+        name: ${{ github.ref_name }} deployed is ${{ vars.DEPLOYED }}
+        shell: bash
+        run: |
+          env
+          if [[ -n "${{ vars.DEPLOYED }}" ]]
+          then
+            if [[ "${{ vars.DEPLOYED }}" == "true" ]]
+            then
+              echo 'action=apply' >> "${GITHUB_OUTPUT}"
+            else
+              echo 'action=destroy' >> "${GITHUB_OUTPUT}"
+            fi
+          else
+            echo 'action=skip' >> "${GITHUB_OUTPUT}"
+          fi
+
+  plan:
+    needs: [terraform]
+    if: needs.terraform.outputs.action == 'apply'
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
+    env:
+      ARM_SKIP_PROVIDER_REGISTRATION: true
+    outputs:
+      tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
+
+    steps:
+      - name: Github repository checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+
+      - name: Microsoft Azure Authentication
+        uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Hashicorp Terraform
+        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        with:
+          terraform_version: 1.6.4
+          terraform_wrapper: false
+
+      - name: terraform init
+        id: init
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          TF_IN_AUTOMATION: true
+          TF_CLI_ARGS_init: -backend-config="storage_account_name=${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}" -backend-config="container_name=${{ secrets.TFSTATE_CONTAINER_NAME }}" -backend-config="resource_group_name=${{ secrets.AZURE_RESOURCE_GROUP_NAME }}" -backend-config="key=${{ github.ref_name }}" -input=false
+        run: terraform -chdir=terraform init
+
+      - name: terraform plan
+        id: tf-plan
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          TF_IN_AUTOMATION: true
+        run: |
+          export exitcode=0
+          terraform -chdir=terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
+          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+          if [ $exitcode -eq 1 ]; then
+            echo Terraform Plan Failed!
+            exit 1
+          else
+            exit 0
+          fi
+
+      - name: Publish Terraform Plan
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        with:
+          name: tfplan
+          path: tfplan
+
+      - name: Create String Output
+        id: tf-plan-string
+        run: |
+          TERRAFORM_PLAN=$(terraform -chdir=terraform show -no-color tfplan)
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "summary<<${delimiter}"
+            echo "## Terraform Plan Output"
+            echo "<details><summary>Click to expand</summary>"
+            echo ""
+            echo '```terraform'
+            echo "$TERRAFORM_PLAN"
+            echo '```'
+            echo "</details>"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish Terraform Plan to Task Summary
+        env:
+          SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
+        run: |
+          echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+
+      # - name: Push Terraform Output to PR
+      #   if: github.ref != 'refs/heads/main'
+      #   uses: actions/github-script@v6
+      #   env:
+      #     SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       const body = `${process.env.SUMMARY}`;
+      #        github.rest.issues.createComment({
+      #          issue_number: context.issue.number,
+      #          owner: context.repo.owner,
+      #          repo: context.repo.repo,
+      #          body: body
+      #        })
+
+  apply:
+    name: Terraform Apply
+    if: needs.terraform.outputs.action == 'apply'
+    environment:
+      name: ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    needs: [terraform, plan]
+    steps:
+      - name: Github repository checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+
+      - name: Microsoft Azure Authentication
+        uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Hashicorp Terraform
+        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        with:
+          terraform_version: 1.6.4
+          terraform_wrapper: false
+
+      - name: terraform init
+        id: init
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          TF_IN_AUTOMATION: true
+          TF_CLI_ARGS_init: -backend-config="storage_account_name=${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}" -backend-config="container_name=${{ secrets.TFSTATE_CONTAINER_NAME }}" -backend-config="resource_group_name=${{ secrets.AZURE_RESOURCE_GROUP_NAME }}" -backend-config="key=${{ github.ref_name }}" -input=false
+        run: terraform -chdir=terraform init
+
+      - name: Download Terraform Plan
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: tfplan
+
+      - name: Terraform Apply
+        id: apply
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          TF_IN_AUTOMATION: true
+        run: terraform -chdir=terraform apply -auto-approve tfplan
+
+  destroy:
+    name: Terraform Destroy
+    needs: [terraform]
+    if: needs.terraform.outputs.action == 'destroy'
+    environment:
+      name: ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Github repository checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+
+      - name: Microsoft Azure Authentication
+        uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Hashicorp Terraform
+        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        with:
+          terraform_version: 1.6.4
+          terraform_wrapper: false
+
+      - name: terraform init
+        id: init
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          TF_IN_AUTOMATION: true
+          TF_CLI_ARGS_init: -backend-config="storage_account_name=${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}" -backend-config="container_name=${{ secrets.TFSTATE_CONTAINER_NAME }}" -backend-config="resource_group_name=${{ secrets.AZURE_RESOURCE_GROUP_NAME }}" -backend-config="key=${{ github.ref_name }}" -input=false
+        run: terraform -chdir=terraform init
+
+      - name: terraform destroy
+        id: destroy
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          TF_IN_AUTOMATION: true
+        run: |
+          terraform -chdir=terraform destroy -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+creds.json
 .chrome/
 !**/.gitkeep
 *$py.class

--- a/docs/Azure-Cloud-Shell.md
+++ b/docs/Azure-Cloud-Shell.md
@@ -8,7 +8,7 @@ comments: true
 
 ![Screenshot showing how to start Azure Cloud Shell in the Azure portal.](img/azure-cloud-shell.png)
 
-!!! info "The first time you start Cloud Shell you're prompted to create an Azure Storage account for the Azure file share."
+!!! info "The first time starting Cloud Shell requires completing the initialization wizard."
 
 - Click `Show advanced settings`
 

--- a/docs/azure-service-principal.md
+++ b/docs/azure-service-principal.md
@@ -1,0 +1,20 @@
+
+az account set -s CSE-SE-DevOps
+
+az group create -n myusername-tfstate-RG -l canadacentral
+az storage account create -n myusernamesaccount -g myusername-tfstate-RG -l canadacentral --sku Standard_LRS
+az storage container create -n myusernametfstate
+
+gh secret set AZURE_STORAGE_ACCOUNT_NAME -b "myusernamesaccount"
+gh secret set TFSTATE_CONTAINER_NAME -b "myusernametfstate"
+gh secret set AZURE_RESOURCE_GROUP_NAME -b "myusername-tfstate-RG"
+
+az account list --query "[?name=='CSE-SE-DevOps'].id" --output tsv
+az ad sp create-for-rbac --name "myapp" --role contributor --scopes /subscriptions/{subscription-id} --json-auth > creds.json
+
+gh secret set ARM_SUBSCRIPTION_ID -b "`jq -r .subscriptionId creds.json`"
+gh secret set ARM_TENANT_ID -b "`jq -r .tenantId creds.json`"
+gh secret set ARM_CLIENT_ID -b "`jq -r .clientId creds.json`"
+gh secret set ARM_CLIENT_SECRET -b "`jq -r .clientSecret creds.json`"
+
+gh secret set AZURE_CREDENTIALS -b "`jq -c . creds.json`"

--- a/doit.sh
+++ b/doit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#
+
 #google-chrome --headless=new --screenshot="docs/img/github-profile.png" --hide-scrollbars --window-size=1620,1080 "https://github.com/robinmordasiewicz"
 
 #google-chrome --headless=new --screenshot="docs/img/github-fork-repo.png" --hide-scrollbars --window-size=1620,1080 "https://github.com/robinmordasiewicz/devops-toolkit/fork"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -18,6 +18,8 @@ terraform {
       version = "3.4.0"
     }
   }
+  backend "azurerm" {
+  }
 }
 
 provider "azurerm" {


### PR DESCRIPTION
A new Terraform workflow has been added to the GitHub Actions. This workflow will automate the process of initializing, planning, and applying Terraform configurations. It also includes steps for destroying resources when necessary. The workflow is triggered on push events that involve changes to Terraform files and on manual workflow dispatch events.

The documentation has been updated to reflect the new workflow and provide instructions for setting up Azure service principals, which are required for the workflow to interact with Azure resources.

The creds.json file, which is expected to contain Azure service principal credentials, has been added to .gitignore to prevent accidental commits of sensitive information.

A minor formatting change was made in the doit.sh script for better readability.

The terraform.tf file has been updated to include a backend configuration. This allows Terraform state data to be stored in Azure, providing a shared source of truth for the state of Azure resources and enabling team collaboration.