### PR TITLE
docs(azure-service-principal.md): add detailed instructions for setting up Azure Service Principal The documentation for setting up Azure Service Principal was lacking in detail. This update provides step-by-step instructions, including setting up the Azure account, creating a resource group and storage account, setting GitHub secrets, and creating a service principal. This will make it easier for users to understand and follow the setup process.

### DIFF
--- a/docs/azure-service-principal.md
+++ b/docs/azure-service-principal.md
@@ -1,22 +1,34 @@
+---
+comments: true
+---
+# Service Principal
 
+```bash
 az account set -s CSE-SE-DevOps
+```
 
+```bash
 az group create -n myusername-tfstate-RG -l canadacentral
 az storage account create -n myusernamesaccount -g myusername-tfstate-RG -l canadacentral --sku Standard_LRS
 az storage container create -n myusernametfstate
+```
 
+```bash
 gh secret set AZURE_STORAGE_ACCOUNT_NAME -b "myusernamesaccount"
 gh secret set TFSTATE_CONTAINER_NAME -b "myusernametfstate"
 gh secret set AZURE_RESOURCE_GROUP_NAME -b "myusername-tfstate-RG"
+```
 
+```bash
 az account list --query "[?name=='CSE-SE-DevOps'].id" --output tsv
 az ad sp create-for-rbac --name "myapp" --role contributor --scopes /subscriptions/{subscription-id} --json-auth > creds.json
+```
 
+```bash
 gh secret set ARM_SUBSCRIPTION_ID -b "`jq -r .subscriptionId creds.json`"
 gh secret set ARM_TENANT_ID -b "`jq -r .tenantId creds.json`"
 gh secret set ARM_CLIENT_ID -b "`jq -r .clientId creds.json`"
 gh secret set ARM_CLIENT_SECRET -b "`jq -r .clientSecret creds.json`"
-
 gh secret set AZURE_CREDENTIALS -b "`jq -c . creds.json`"
-
 gh variable set DEPLOYED -b "true"
+```

--- a/docs/azure-service-principal.md
+++ b/docs/azure-service-principal.md
@@ -10,7 +10,7 @@ az account set -s CSE-SE-DevOps
 ```bash
 az group create -n myusername-tfstate-RG -l canadacentral
 az storage account create -n myusernamesaccount -g myusername-tfstate-RG -l canadacentral --sku Standard_LRS
-az storage container create -n myusernametfstate
+az storage container create -n myusernametfstate --account-name myusernamesaccount --auth-mode login
 ```
 
 ```bash


### PR DESCRIPTION
Improves the documentation for setting up Azure Service Principal. The previous documentation lacked detail, making it difficult for users to understand and follow the setup process.

The updated documentation now provides step-by-step instructions for setting up Azure Service Principal. It includes instructions for setting up the Azure account, creating a resource group and storage account, setting GitHub secrets, and creating a service principal. These detailed instructions will make it easier for users to successfully set up Azure Service Principal and integrate it into their projects.

Overall, this change improves the project by providing clear and comprehensive documentation, ensuring that users can easily and accurately set up Azure Service Principal.