### PR TITLE
fix(terraform.yml): change path of tfplan from 'tfplan' to 'terraform…

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         with:
           name: tfplan
-          path: tfplan
+          path: terraform/tfplan
 
       - name: Create String Output
         id: tf-plan-string


### PR DESCRIPTION
…/tfplan'

The path of the tfplan file was incorrect, causing the GitHub action to fail. The correct path is 'terraform/tfplan', which is where the tfplan file is actually located. This change ensures that the GitHub action can find and use the tfplan file as expected.