### PR TITLE
feat(terraform.yml): add path parameter to download-artifact action in GitHub workflow The path parameter is added to the download-artifact action in the GitHub workflow to specify the location where the downloaded artifact should be stored. This change provides better organization and management of downloaded artifacts, making it easier to locate and use them in subsequent steps of the workflow.

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -176,6 +176,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: tfplan
+          path: terraform/tfplan
 
       - name: Terraform Apply
         id: apply


### PR DESCRIPTION
Adds a new feature to our GitHub workflow for Terraform. Specifically, it adds a path parameter to the download-artifact action. This parameter allows us to specify the location where the downloaded artifact should be stored.

By adding this path parameter, we can better organize and manage the downloaded artifacts in our workflow. This makes it easier to locate and use the artifacts in subsequent steps of the workflow.

Overall, this change improves the project by providing better organization and management of downloaded artifacts in our Terraform workflow.