### PR TITLE
fix(terraform.yml): modify path for downloaded artifact to correct directory feat(mkdocs.yml): add azure-service-principal.md to CI/CD section in navigation

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -176,7 +176,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: tfplan
-          path: terraform/tfplan
+          path: terraform
 
       - name: Terraform Apply
         id: apply

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
       - github-merge.md
       - fortinet-fortidevsec.md
   - "CI/CD":
+      - azure-service-principal.md
       - github-personal-access-token.md
       - github-secrets.md
       - terraform-docs.md


### PR DESCRIPTION
The path for the downloaded artifact in the terraform.yml file was incorrect, causing the Terraform Apply step to fail. This change corrects the path, ensuring the artifact is placed in the correct directory for the apply step to succeed.

In the mkdocs.yml file, a new document azure-service-principal.md has been added to the CI/CD section in the navigation. This provides additional information on Azure Service Principal, enhancing the documentation's coverage of CI/CD topics.