### PR TITLE
docs(azure-service-principal.md): add detailed instructions for setting up Azure Service Principal The documentation now includes more detailed instructions for setting up Azure Service Principal. This includes steps for setting the default subscription, creating an Azure Resource group for storing the Terraform state, creating GitHub secrets, and creating a service principal. These changes were made to provide clearer guidance for users and to reduce potential setup errors.

### DIFF
--- a/docs/azure-service-principal.md
+++ b/docs/azure-service-principal.md
@@ -3,9 +3,13 @@ comments: true
 ---
 # Service Principal
 
+- Set the default subscription.
+
 ```bash
 az account set -s CSE-SE-DevOps
 ```
+
+- Create an Azure Resource group to store the Terraform state.
 
 ```bash
 az group create -n myusername-tfstate-RG -l canadacentral
@@ -13,16 +17,22 @@ az storage account create -n myusernamesaccount -g myusername-tfstate-RG -l cana
 az storage container create -n myusernametfstate --account-name myusernamesaccount --auth-mode login
 ```
 
+- Create GitHub secrets.
+
 ```bash
 gh secret set AZURE_STORAGE_ACCOUNT_NAME -b "myusernamesaccount"
 gh secret set TFSTATE_CONTAINER_NAME -b "myusernametfstate"
 gh secret set AZURE_RESOURCE_GROUP_NAME -b "myusername-tfstate-RG"
 ```
 
+- Create a service principal.
+
 ```bash
 az account list --query "[?name=='CSE-SE-DevOps'].id" --output tsv
 az ad sp create-for-rbac --name "myapp" --role contributor --scopes /subscriptions/{subscription-id} --json-auth > creds.json
 ```
+
+- Create GitHub secrets.
 
 ```bash
 gh secret set ARM_SUBSCRIPTION_ID -b "`jq -r .subscriptionId creds.json`"


### PR DESCRIPTION
Enhances the documentation for setting up Azure Service Principal. The changes include more detailed instructions for various steps, such as setting the default subscription, creating an Azure Resource group for storing the Terraform state, creating GitHub secrets, and creating a service principal.

The motivation behind these changes is to provide clearer guidance for users and reduce potential setup errors. By including step-by-step instructions and clear examples, users will have a better understanding of the process and be able to set up Azure Service Principal more effectively.

Overall, these improvements will greatly enhance the usability of the documentation and improve the onboarding experience for users.