### PR TITLE
feat(create-article.yml): add self to paths to trigger workflow on changes The workflow now triggers not only when changes are made to the JSON files in the "docs/concepts/articles" directory, but also when changes are made to the workflow file itself. This ensures that any modifications to the workflow are immediately tested, providing quicker feedback on the impact of the changes.

### DIFF
--- a/.github/workflows/create-article.yml
+++ b/.github/workflows/create-article.yml
@@ -67,7 +67,8 @@ jobs:
         run: |
           # checkov:skip=CKV_GHA_3: "Suspicious use of curl with secrets"
           curl -s -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.OPENAI_API_KEY }}" -d @${{ matrix.manifest }} https://api.openai.com/v1/chat/completions | jq -r '.choices[0].message.content' > docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
-          if egrep -q '^```' -m 1 docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md && awk '{last=$0} END {print last}' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md | egrep '^```$'` ; then
+          #if egrep -q '^```' -m 1 docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md && awk '{last=$0} END {print last}' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md | egrep '^```$'` ; then
+          if egrep -q '^```' -m 1 docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md ; then
             sed -i '0,/^``/ { /^``/d }' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
             sed -i '$d' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
           fi

--- a/.github/workflows/create-article.yml
+++ b/.github/workflows/create-article.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # checkov:skip=CKV_GHA_3: "Suspicious use of curl with secrets"
           curl -s -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.OPENAI_API_KEY }}" -d @${{ matrix.manifest }} https://api.openai.com/v1/chat/completions | jq -r '.choices[0].message.content' > docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
-          if [[ `egrep '^```' -m 1 docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md && awk '{last=$0} END {print last}' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md | egrep '^```$'` ]]; then
+          if egrep -q '^```' -m 1 docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md && `awk '{last=$0} END {print last}' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md | egrep '^```$'`` ; then
             sed -i '0,/^``/ { /^``/d }' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
             sed -i '$d' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
           fi

--- a/.github/workflows/create-article.yml
+++ b/.github/workflows/create-article.yml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - main
     paths:
       - "docs/concepts/articles/*.json"
+      - .github/workflows/create-article.yml
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/create-article.yml
+++ b/.github/workflows/create-article.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # checkov:skip=CKV_GHA_3: "Suspicious use of curl with secrets"
           curl -s -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.OPENAI_API_KEY }}" -d @${{ matrix.manifest }} https://api.openai.com/v1/chat/completions | jq -r '.choices[0].message.content' > docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
-          if egrep -q '^```' -m 1 docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md && `awk '{last=$0} END {print last}' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md | egrep '^```$'`` ; then
+          if egrep -q '^```' -m 1 docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md && awk '{last=$0} END {print last}' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md | egrep '^```$'` ; then
             sed -i '0,/^``/ { /^``/d }' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
             sed -i '$d' docs/concepts/articles/`basename -s .json ${{ matrix.manifest }}`.md
           fi

--- a/docs/concepts/articles/source-control-management.md
+++ b/docs/concepts/articles/source-control-management.md
@@ -1,4 +1,3 @@
-```markdown
 ---
 title: Source Code Management
 author: robinmordasiewicz
@@ -6,16 +5,16 @@ date: 2023-11-30
 comments: true
 ---
 
-Source Code Management (SCM) plays a vital role in Software Development Life Cycle (SDLC), Quality Assurance (QA), staging, and promotion to production environments. It provides a systematic approach to tracking and managing changes to code, thereby avoiding confusion and ensuring that every change can be audited. In the world of DevOps, SCM is the foundation on which everything else is built.
+Source Code Management (SCM) plays a vital role in Software Development Life Cycle (SDLC), Quality Assurance (QA), staging, and promotion to production environments. It is the bedrock upon which DevOps principles stand, facilitating streamlined deployment and integration processes. SCM is essential due to its ability to track modifications, collaborative features, and aiding in the prevention of conflicts amongst shared codebases.
 
 <!-- more -->
 
-GitHub is the leading platform for SCM, but it's not the only player in the field. Other widely used SCMs include:
+As per the adoption trend, GitHub is the leading SCM system worth special mention. However, the choice of an SCM tool can be driven by project requirements. Below are the top four SCMs with their respective links:
 
-- [:fa-github: GitHub](https://github.com)
-- [:fa-gitlab: GitLab](https://about.gitlab.com)
-- [:fa-bitbucket: Bitbucket](https://bitbucket.org)
-- [:fa-perforce: Perforce](https://www.perforce.com)
+- [:octocat: GitHub](https://github.com/)
+- [:icon-gitlab: GitLab](https://about.gitlab.com/)
+- [:icon-bitbucket: Bitbucket](https://bitbucket.org/)
+- [:fa-perforce: Perforce](https://www.perforce.com/)
 
-Git, the underlying version control system used by these SCM platforms, is integral to Continuous Integration and Continuous Delivery (CICD) in a DevOps lifecycle. It allows developers to collaborate on code, automates testing, and delivers updates faster and more reliably.
+Embedded at the heart of any Continuous Integration/Continuous Development (CICD) DevOps pipeline is the system Git. Git offers a robust, distributed approach expediting frequent commits and updates, thus ensuring code integration into a shared repository without overwriting changes. It underpins quick detection and resolution of conflicts, enhancing the team's ability to collaborate and manage code across various development stages.
 ```


### PR DESCRIPTION
Updates the "create-article.yml" workflow file to trigger the workflow not only when changes are made to the JSON files in the "docs/concepts/articles" directory, but also when changes are made to the workflow file itself. 

By including the workflow file in the trigger paths, any modifications made to the workflow will be immediately tested, providing quicker feedback on the impact of the changes. This ensures that any potential issues or errors introduced in the workflow file are caught early in the development process.

Overall, this change improves the project by increasing the reliability and efficiency of the workflow, leading to a smoother development and deployment process.