### PR TITLE
refactor(terraform.tf): comment out azurerm backend configuration The AzureRM backend configuration has been commented out. This change was made because the backend was not being used in the current setup. This will prevent unnecessary AzureRM backend initialization during Terraform operations, reducing complexity and potential errors.

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -18,8 +18,8 @@ terraform {
       version = "3.4.0"
     }
   }
-  backend "azurerm" {
-  }
+  #backend "azurerm" {
+  #}
 }
 
 provider "azurerm" {


### PR DESCRIPTION
The AzureRM backend configuration in the `terraform.tf` file has been commented out in this pull request. This change was made because the backend was not being used in the current setup. By commenting out the backend configuration, we prevent unnecessary AzureRM backend initialization during Terraform operations. This reduces complexity and potential errors in our project.

Overall, this refactor improves the project by simplifying the Terraform setup and ensuring that only necessary configurations are used.