### PR TITLE
fix(favicon.json): update favicon content from "MC" to "8" horizontally The favicon content was updated to display a horizontal "8" instead of "MC". This change was made to better align with the new branding guidelines which require the use of a horizontal "8" as the favicon.

### DIFF
--- a/.github/workflows/create-logo.yml
+++ b/.github/workflows/create-logo.yml
@@ -7,7 +7,7 @@ on: # yamllint disable-line rule:truthy
       - main
     paths:
       - "docs/logo.json"
-      - "docs/icon.json"
+      - "docs/favicon.json"
       - .github/workflows/create-logo.yml
 
 concurrency:

--- a/docs/favicon.json
+++ b/docs/favicon.json
@@ -8,7 +8,7 @@
     },
     {
       "role": "user",
-      "content": "Create a favicon with the text \"MC\""
+      "content": "Create a favicon with the number 8 on its side horizontally"
     }
   ]
 }

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,6 +1,5 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve" overflow="visible">
-  <style type="text/css">
-    .st0{font-family:'Roboto-Bold'; text-anchor: middle; font-size:16px;}
-  </style>
-  <text transform="matrix(1 0 0 1 8 12)" class="st0" fill="#FFFFFF">MC</text>
+<svg width="16px" height="16px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" overflow="visible">
+  <text x="50%" y="50%" dy=".35em" text-anchor="middle" style="font-size: 16px; font-weight: bold; font-family: 'Roboto', Arial, sans-serif; fill: #FFFFFF;" transform="rotate(90 8,8)">
+    8
+  </text>
 </svg>


### PR DESCRIPTION
Updates the favicon content from "MC" to a horizontal "8". The change aligns with our new branding guidelines, which require the use of a horizontal "8" as the favicon. 

By updating the favicon content, we ensure that our branding is consistent across all platforms and better reflects our brand identity. This change improves the project by bringing it in line with our updated branding guidelines.