### PR TITLE
chore(terraform): upgrade terraform version from 1.6.4 to 1.6.5 The terraform version has been upgraded from 1.6.4 to 1.6.5 in the GitHub workflows and the terraform configuration file. This upgrade is necessary to take advantage of the latest features, improvements, and bug fixes in the newer version of terraform.

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Hashicorp Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
-          terraform_version: 1.6.4
+          terraform_version: 1.6.5
           terraform_wrapper: false
 
       - name: terraform init
@@ -158,7 +158,7 @@ jobs:
       - name: Hashicorp Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
-          terraform_version: 1.6.4
+          terraform_version: 1.6.5
           terraform_wrapper: false
 
       - name: terraform init
@@ -205,7 +205,7 @@ jobs:
       - name: Hashicorp Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
-          terraform_version: 1.6.4
+          terraform_version: 1.6.5
           terraform_wrapper: false
 
       - name: terraform init

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -10,6 +10,63 @@ classDef ms fill:none,stroke:#dce0e6,stroke-width:2px
 classDef vs fill:none,stroke:#dce0e6,stroke-width:4px,stroke-dasharray:10
 classDef ps fill:none,stroke:none
 classDef cs fill:#f7f8fa,stroke:#dce0e6,stroke-width:2px
+subgraph "n0"["Compute"]
+n1["azurerm_availability_set.<br/>fortinet_availability_set"]:::r
+n2["azurerm_linux_virtual_machine.<br/>fortigate_virtual_machine"]:::r
+end
+class n0 cs
+subgraph "n3"["Network"]
+n4["azurerm_network_interface.<br/>fortigate_dmz_network_interface"]:::r
+n5["azurerm_network_interface.<br/>fortigate_external_network_interface"]:::r
+n6["azurerm_network_interface_security_group_association.<br/>fortigate_association"]:::r
+n7["azurerm_network_security_group.<br/>nsg"]:::r
+n8["azurerm_network_security_group.<br/>private_nsg"]:::r
+n9["azurerm_network_security_group.<br/>vip_allow_https_tcp_nsg"]:::r
+na["azurerm_public_ip.<br/>fortigate_public_ip"]:::r
+nb["azurerm_public_ip.<br/>vip_public_ip"]:::r
+nc["azurerm_subnet.dmz_subnet"]:::r
+nd["azurerm_subnet.<br/>external_subnet"]:::r
+ne["azurerm_subnet.<br/>internal_subnet"]:::r
+nf["azurerm_subnet_network_security_group_association.<br/>dmz_subnet_association"]:::r
+ng["azurerm_subnet_network_security_group_association.<br/>external_subnet_association"]:::r
+nh["azurerm_subnet_network_security_group_association.<br/>internal_subnet_association"]:::r
+ni["azurerm_virtual_network.vnet"]:::r
+end
+class n3 cs
+subgraph "nj"["Base"]
+nk["azurerm_resource_group.<br/>azure_resource_group"]:::r
+end
+class nj cs
+nl["random_integer.random_number"]:::r
+nm["random_pet.admin_username"]:::r
+nn["tls_private_key.ssh_key"]:::r
+nk-->n1
+n1-->n2
+n4-->n2
+n5-->n2
+nm-->n2
+nn-->n2
+nc-->n4
+nb-->n5
+nd-->n5
+n5-->n6
+n9-->n6
+nk-->n7
+nk-->n8
+nk-->n9
+nk-->na
+nk-->nb
+ni-->nc
+ni-->nd
+ni-->ne
+n8-->nf
+nc-->nf
+n8-->ng
+nd-->ng
+n8-->nh
+ne-->nh
+nk-->ni
+nk-->nm
 ```
 
 <!-- BEGIN_TF_DOCS -->
@@ -33,7 +90,7 @@ internal_prefix     = "10.0.3.0/24"
 
 | Name | Version |
 |------|---------|
-| terraform | 1.6.4 |
+| terraform | 1.6.5 |
 | azurerm | 3.83.0 |
 | http | 3.4.0 |
 | random | 3.5.1 |

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.6.4"
+  required_version = "1.6.5"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
Upgrades the Terraform version from 1.6.4 to 1.6.5 in both the GitHub workflows and the Terraform configuration file. The upgrade is necessary to take advantage of the latest features, improvements, and bug fixes in the newer version of Terraform.

By upgrading the Terraform version, we ensure that our infrastructure provisioning and management processes are using the most up-to-date tools available. This enhances the stability, performance, and security of our project's infrastructure.

Overall, this change improves the project by keeping our infrastructure codebase aligned with the latest advancements in Terraform.