### PR TITLE
style(extra.css): add border styling to .md-typeset .admonition and .md-typeset details for better visual distinction feat(mkdocs.yml): enable edit_uri to allow direct editing of docs from the site fix(mkdocs.yml): remove content.action.edit and content.code.select from theme features for cleaner UI

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,3 +1,8 @@
+.md-typeset .admonition,
+.md-typeset details {
+  border-width: 0;
+  border-left-width: 4px;
+}
 .md-grid {
   margin-left: 0;
   max-width: 75rem;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ site_author: Robin Mordasiewicz
 
 repo_name: "robinmordasiewicz/devops-toolkit"
 repo_url: https://github.com/robinmordasiewicz/devops-toolkit/
-# edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/
 
 # yamllint disable-line rule:line-length
 copyright: "Try to be nice."
@@ -44,11 +44,9 @@ theme:
     repo: fontawesome/brands/github
   features:
     - announce.dismiss
-    - content.action.edit
     - content.action.view
     - content.code.annotate
     - content.code.copy
-    # - content.code.select
     # - content.tabs.link
     - content.tooltips
     - header.autohide


### PR DESCRIPTION
The border styling added to .md-typeset .admonition and .md-typeset details in extra.css improves the visual distinction of these elements, enhancing readability. The edit_uri is enabled in mkdocs.yml to provide a direct link for editing the documentation from the site, improving user experience. The removal of content.action.edit and content.code.select from theme features declutters the UI, making it more user-friendly.