### PR TITLE
Fix: updating terraform

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -33,7 +33,7 @@ internal_prefix     = "10.0.3.0/24"
 
 | Name | Version |
 |------|---------|
-| terraform | 1.6.5 |
+| terraform | 1.7.0 |
 | azurerm | 3.88.0 |
 | http | 3.4.1 |
 | random | 3.6.0 |

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.6.5"
+  required_version = "1.7.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
Updates the version of Terraform used in our project from 1.6.5 to 1.7.0. 

The motivation behind this change is to stay up-to-date with the latest version of Terraform, which may include bug fixes, performance improvements, and new features. By updating the version, we ensure that our infrastructure code is built and managed using the most recent tools and capabilities available.

Overall, this change improves the project by leveraging the benefits of the latest Terraform version and ensuring that our infrastructure code is built on a solid foundation.