### PR TITLE
Fix: updating terraform

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,10 +40,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # If you use VALIDATE_ALL_CODEBASE = true, you can remove this line to improve performances
 
-      - name: set .git folder as safe
+      - name: Set ownership
         run: |
-          git config --global --add safe.directory /github/workspace/.git
-          git config --global --add safe.directory /github/workspace
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
 
       # MegaLinter
       - name: MegaLinter


### PR DESCRIPTION
Addresses an issue with the Terraform update in our project. The issue was causing errors related to the ownership of the checkout directory in Git.

To fix this issue, we have added a step in the linter workflow to set the ownership of the checkout directory using the `chown` command. This ensures that the ownership is correctly set, resolving the error.

This change improves the project by allowing the Terraform update to proceed without any issues related to ownership. It ensures that our project can continue to be developed and maintained smoothly.

Overall, this fix improves the stability and functionality of our project by resolving the Terraform update issue.