### PR TITLE
Fix: make terraform-docs work

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -33,7 +33,7 @@ internal_prefix     = "10.0.3.0/24"
 
 | Name | Version |
 |------|---------|
-| terraform | 1.7.0 |
+| terraform | 1.7.1 |
 | azurerm | 3.89.0 |
 | http | 3.4.1 |
 | random | 3.6.0 |
@@ -51,7 +51,7 @@ internal_prefix     = "10.0.3.0/24"
 | internal\_prefix | Internal Subnet Prefix. | `string` | n/a | yes |
 | location | Azure region for resource group. | `string` | n/a | yes |
 | owner\_email | Email address for use with Azure Owner tag. | `string` | n/a | yes |
-| resource\_group | Unique name of the Azure resource group. | `string` | n/a | yes |
+| resource\_group | Azure resource group. | `string` | n/a | yes |
 | vnet\_address\_prefix | Virtual Network Address prefix. | `string` | n/a | yes |
 ## Outputs
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,7 +9,7 @@ variable "location" {
 }
 
 variable "resource_group" {
-  description = "Unique name of the Azure resource group."
+  description = "Azure resource group."
   type        = string
 }
 


### PR DESCRIPTION
Addresses an issue with the `terraform-docs` functionality in our project. Currently, the documentation generated by `terraform-docs` includes an incorrect description for the `resource_group` variable. This pull request updates the description to accurately reflect that it represents the Azure resource group.

By fixing this issue, we ensure that the generated documentation is correct and provides accurate information about the variables used in our Terraform configuration. This improvement helps developers and users of our project to have a clear understanding of the purpose and usage of the `resource_group` variable.

Overall, this change enhances the project's documentation and improves the user experience by providing accurate and informative documentation.