### PR TITLE
commit(.pre-commit-config.yaml): remove commented out terraform\_docs hook configuration to simplify file and improve readability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.88.4
     hooks:
-      - id: terraform_docs
-        args:
-          - --hook-config=--path-to-file=README.md
-          - --hook-config=--add-to-existing-file=true
-          - --hook-config=--create-file-if-not-exist=true
-          - --hook-config=--use-standard-markers=true
+      # - id: terraform_docs
+      #   args:
+      #     - --hook-config=--path-to-file=README.md
+      #     - --hook-config=--add-to-existing-file=true
+      #     - --hook-config=--create-file-if-not-exist=true
+      #     - --hook-config=--use-standard-markers=true
       - id: terraform_fmt
         args:
           - --args=-recursive

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,74 +1,96 @@
-# Terraform Docs
+# Changing PIP/UDR
+
+## Diagram
+
+![Changing PIP/UDR](https://learn.microsoft.com/en-us/azure/architecture/networking/guide/images/nvaha-pipudr-internet.png)
 
 ## Sizing
 
 https://learn.microsoft.com/en-us/azure/virtual-machines/fsv2-series
 
-## Diagram
-
-```mermaid
-%%tfmermaid
-%%{init:{"theme":"default","themeVariables":{"lineColor":"#6f7682","textColor":"#6f7682"}}}%%
-flowchart LR
-classDef r fill:#5c4ee5,stroke:#444,color:#fff
-classDef v fill:#eeedfc,stroke:#eeedfc,color:#5c4ee5
-classDef ms fill:none,stroke:#dce0e6,stroke-width:2px
-classDef vs fill:none,stroke:#dce0e6,stroke-width:4px,stroke-dasharray:10
-classDef ps fill:none,stroke:none
-classDef cs fill:#f7f8fa,stroke:#dce0e6,stroke-width:2px
-```
-
 <!-- BEGIN_TF_DOCS -->
-## terraform.auto.tfvars
-
-```hcl
-location                             = "canadacentral"
-resource_group                       = "my-resource-group"
-owner_email                          = "root@example.com"
-hub-virtual-network_address_prefix   = "10.0.0.0/16"
-hub-external-subnet_name             = "hub-external_subnet"
-hub-external-subnet_prefix           = "10.0.1.0/24"
-hub-internal-subnet_name             = "hub-internal_subnet"
-hub-internal-subnet_prefix           = "10.0.2.0/24"
-spoke-virtual-network_address_prefix = "10.1.0.0/16"
-spoke-subnet_name                    = "spoke_subnet"
-spoke-subnet_prefix                  = "10.1.0.0/24"
-```
-
-
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | 1.8.0 |
-| azurerm | 3.99.0 |
-| http | 3.4.1 |
-| random | 3.6.0 |
-| tls | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.8.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | 3.4.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_availability_set.hub-nva_availability_set](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/availability_set) | resource |
+| [azurerm_linux_virtual_machine.hub-nva_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/linux_virtual_machine) | resource |
+| [azurerm_linux_virtual_machine.spoke-container-server_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/linux_virtual_machine) | resource |
+| [azurerm_network_interface.hub-nva-external_network_interface](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_interface) | resource |
+| [azurerm_network_interface.hub-nva-internal_network_interface](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_interface) | resource |
+| [azurerm_network_interface.spoke-container-server_network_interface](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_interface) | resource |
+| [azurerm_network_security_group.hub-external_network_security_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_security_group) | resource |
+| [azurerm_network_security_group.hub-internal_network_security_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_security_group) | resource |
+| [azurerm_network_security_group.spoke_network_security_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip.hub-nva-management_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/public_ip) | resource |
+| [azurerm_public_ip.hub-nva-vip_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.azure_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_route_table.hub_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/route_table) | resource |
+| [azurerm_route_table.spoke_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/route_table) | resource |
+| [azurerm_subnet.hub-external_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.hub-internal_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.spoke_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_network_security_group_association.hub-external-subnet-network-security-group_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_network_security_group_association.hub-internal-subnet-network-security-group_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_network_security_group_association.spokesubnet-network-security-group__association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_route_table_association.hub-external-route-table_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_subnet_route_table_association.hub-internal-routing-table_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_subnet_route_table_association.spoke-route-table_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_virtual_network.hub_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network.spoke_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.hub-to-spoke_virtual_network_peering](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network_peering) | resource |
+| [azurerm_virtual_network_peering.spoke-to-hub_virtual_network_peering](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network_peering) | resource |
+| [random_integer.random_number](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/integer) | resource |
+| [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/password) | resource |
+| [random_pet.admin_username](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/pet) | resource |
+| [azurerm_public_ip.hub-nva-management_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/public_ip) | data source |
+| [azurerm_public_ip.hub-nva-vip_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/public_ip) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| hub-external-subnet\_name | External Subnet Name. | `string` | n/a | yes |
-| hub-external-subnet\_prefix | External Subnet Prefix. | `string` | n/a | yes |
-| hub-internal-subnet\_name | Hub Subnet Name. | `string` | n/a | yes |
-| hub-internal-subnet\_prefix | Hub Subnet Prefix. | `string` | n/a | yes |
-| hub-virtual-network\_address\_prefix | Hub Virtual Network Address prefix. | `string` | n/a | yes |
-| location | Azure region for resource group. | `string` | n/a | yes |
-| owner\_email | Email address for use with Azure Owner tag. | `string` | n/a | yes |
-| resource\_group | Azure resource group. | `string` | n/a | yes |
-| spoke-subnet\_name | Spoke Subnet Name. | `string` | n/a | yes |
-| spoke-subnet\_prefix | Spoke Subnet Prefix. | `string` | n/a | yes |
-| spoke-virtual-network\_address\_prefix | Spoke Virtual Network Address prefix. | `string` | n/a | yes |
+| <a name="input_hub-external-subnet_name"></a> [hub-external-subnet\_name](#input\_hub-external-subnet\_name) | External Subnet Name. | `string` | n/a | yes |
+| <a name="input_hub-external-subnet_prefix"></a> [hub-external-subnet\_prefix](#input\_hub-external-subnet\_prefix) | External Subnet Prefix. | `string` | n/a | yes |
+| <a name="input_hub-internal-subnet_name"></a> [hub-internal-subnet\_name](#input\_hub-internal-subnet\_name) | Hub Subnet Name. | `string` | n/a | yes |
+| <a name="input_hub-internal-subnet_prefix"></a> [hub-internal-subnet\_prefix](#input\_hub-internal-subnet\_prefix) | Hub Subnet Prefix. | `string` | n/a | yes |
+| <a name="input_hub-virtual-network_address_prefix"></a> [hub-virtual-network\_address\_prefix](#input\_hub-virtual-network\_address\_prefix) | Hub Virtual Network Address prefix. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Azure region for resource group. | `string` | n/a | yes |
+| <a name="input_owner_email"></a> [owner\_email](#input\_owner\_email) | Email address for use with Azure Owner tag. | `string` | n/a | yes |
+| <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Azure resource group. | `string` | n/a | yes |
+| <a name="input_spoke-subnet_name"></a> [spoke-subnet\_name](#input\_spoke-subnet\_name) | Spoke Subnet Name. | `string` | n/a | yes |
+| <a name="input_spoke-subnet_prefix"></a> [spoke-subnet\_prefix](#input\_spoke-subnet\_prefix) | Spoke Subnet Prefix. | `string` | n/a | yes |
+| <a name="input_spoke-virtual-network_address_prefix"></a> [spoke-virtual-network\_address\_prefix](#input\_spoke-virtual-network\_address\_prefix) | Spoke Virtual Network Address prefix. | `string` | n/a | yes |
+
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| admin\_password | Password for admin account |
-| admin\_username | Username for admin account |
-| hub-nva-management\_public\_ip | Management IP address |
-| hub-nva-vip\_public\_ip | VIP IP address |
-| management\_fqdn | Management FQDN |
-| vip\_fqdn | VIP FQDN |
+| <a name="output_admin_password"></a> [admin\_password](#output\_admin\_password) | Password for admin account |
+| <a name="output_admin_username"></a> [admin\_username](#output\_admin\_username) | Username for admin account |
+| <a name="output_hub-nva-management_public_ip"></a> [hub-nva-management\_public\_ip](#output\_hub-nva-management\_public\_ip) | Management IP address |
+| <a name="output_hub-nva-vip_public_ip"></a> [hub-nva-vip\_public\_ip](#output\_hub-nva-vip\_public\_ip) | VIP IP address |
+| <a name="output_management_fqdn"></a> [management\_fqdn](#output\_management\_fqdn) | Management FQDN |
+| <a name="output_vip_fqdn"></a> [vip\_fqdn](#output\_vip\_fqdn) | VIP FQDN |
 <!-- END_TF_DOCS -->

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,88 +9,56 @@
 https://learn.microsoft.com/en-us/azure/virtual-machines/fsv2-series
 
 <!-- BEGIN_TF_DOCS -->
+## terraform.auto.tfvars
+
+```hcl
+location                             = "canadacentral"
+resource_group                       = "my-resource-group"
+owner_email                          = "root@example.com"
+hub-virtual-network_address_prefix   = "10.0.0.0/16"
+hub-external-subnet_name             = "hub-external_subnet"
+hub-external-subnet_prefix           = "10.0.1.0/24"
+hub-internal-subnet_name             = "hub-internal_subnet"
+hub-internal-subnet_prefix           = "10.0.2.0/24"
+spoke-virtual-network_address_prefix = "10.1.0.0/16"
+spoke-subnet_name                    = "spoke_subnet"
+spoke-subnet_prefix                  = "10.1.0.0/24"
+```
+
+
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.8.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
-| <a name="requirement_http"></a> [http](#requirement\_http) | 3.4.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [azurerm_availability_set.hub-nva_availability_set](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/availability_set) | resource |
-| [azurerm_linux_virtual_machine.hub-nva_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/linux_virtual_machine) | resource |
-| [azurerm_linux_virtual_machine.spoke-container-server_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/linux_virtual_machine) | resource |
-| [azurerm_network_interface.hub-nva-external_network_interface](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_interface) | resource |
-| [azurerm_network_interface.hub-nva-internal_network_interface](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_interface) | resource |
-| [azurerm_network_interface.spoke-container-server_network_interface](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_interface) | resource |
-| [azurerm_network_security_group.hub-external_network_security_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_security_group) | resource |
-| [azurerm_network_security_group.hub-internal_network_security_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_security_group) | resource |
-| [azurerm_network_security_group.spoke_network_security_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/network_security_group) | resource |
-| [azurerm_public_ip.hub-nva-management_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/public_ip) | resource |
-| [azurerm_public_ip.hub-nva-vip_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/public_ip) | resource |
-| [azurerm_resource_group.azure_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
-| [azurerm_route_table.hub_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/route_table) | resource |
-| [azurerm_route_table.spoke_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/route_table) | resource |
-| [azurerm_subnet.hub-external_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.hub-internal_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.spoke_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
-| [azurerm_subnet_network_security_group_association.hub-external-subnet-network-security-group_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_subnet_network_security_group_association.hub-internal-subnet-network-security-group_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_subnet_network_security_group_association.spokesubnet-network-security-group__association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_subnet_route_table_association.hub-external-route-table_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_subnet_route_table_association.hub-internal-routing-table_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_subnet_route_table_association.spoke-route-table_association](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_virtual_network.hub_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network.spoke_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_peering.hub-to-spoke_virtual_network_peering](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network_peering) | resource |
-| [azurerm_virtual_network_peering.spoke-to-hub_virtual_network_peering](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network_peering) | resource |
-| [random_integer.random_number](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/integer) | resource |
-| [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/password) | resource |
-| [random_pet.admin_username](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/pet) | resource |
-| [azurerm_public_ip.hub-nva-management_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/public_ip) | data source |
-| [azurerm_public_ip.hub-nva-vip_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/public_ip) | data source |
+| terraform | 1.8.0 |
+| azurerm | 3.99.0 |
+| http | 3.4.1 |
+| random | 3.6.0 |
+| tls | 4.0.5 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_hub-external-subnet_name"></a> [hub-external-subnet\_name](#input\_hub-external-subnet\_name) | External Subnet Name. | `string` | n/a | yes |
-| <a name="input_hub-external-subnet_prefix"></a> [hub-external-subnet\_prefix](#input\_hub-external-subnet\_prefix) | External Subnet Prefix. | `string` | n/a | yes |
-| <a name="input_hub-internal-subnet_name"></a> [hub-internal-subnet\_name](#input\_hub-internal-subnet\_name) | Hub Subnet Name. | `string` | n/a | yes |
-| <a name="input_hub-internal-subnet_prefix"></a> [hub-internal-subnet\_prefix](#input\_hub-internal-subnet\_prefix) | Hub Subnet Prefix. | `string` | n/a | yes |
-| <a name="input_hub-virtual-network_address_prefix"></a> [hub-virtual-network\_address\_prefix](#input\_hub-virtual-network\_address\_prefix) | Hub Virtual Network Address prefix. | `string` | n/a | yes |
-| <a name="input_location"></a> [location](#input\_location) | Azure region for resource group. | `string` | n/a | yes |
-| <a name="input_owner_email"></a> [owner\_email](#input\_owner\_email) | Email address for use with Azure Owner tag. | `string` | n/a | yes |
-| <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Azure resource group. | `string` | n/a | yes |
-| <a name="input_spoke-subnet_name"></a> [spoke-subnet\_name](#input\_spoke-subnet\_name) | Spoke Subnet Name. | `string` | n/a | yes |
-| <a name="input_spoke-subnet_prefix"></a> [spoke-subnet\_prefix](#input\_spoke-subnet\_prefix) | Spoke Subnet Prefix. | `string` | n/a | yes |
-| <a name="input_spoke-virtual-network_address_prefix"></a> [spoke-virtual-network\_address\_prefix](#input\_spoke-virtual-network\_address\_prefix) | Spoke Virtual Network Address prefix. | `string` | n/a | yes |
-
+| hub-external-subnet\_name | External Subnet Name. | `string` | n/a | yes |
+| hub-external-subnet\_prefix | External Subnet Prefix. | `string` | n/a | yes |
+| hub-internal-subnet\_name | Hub Subnet Name. | `string` | n/a | yes |
+| hub-internal-subnet\_prefix | Hub Subnet Prefix. | `string` | n/a | yes |
+| hub-virtual-network\_address\_prefix | Hub Virtual Network Address prefix. | `string` | n/a | yes |
+| location | Azure region for resource group. | `string` | n/a | yes |
+| owner\_email | Email address for use with Azure Owner tag. | `string` | n/a | yes |
+| resource\_group | Azure resource group. | `string` | n/a | yes |
+| spoke-subnet\_name | Spoke Subnet Name. | `string` | n/a | yes |
+| spoke-subnet\_prefix | Spoke Subnet Prefix. | `string` | n/a | yes |
+| spoke-virtual-network\_address\_prefix | Spoke Virtual Network Address prefix. | `string` | n/a | yes |
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_admin_password"></a> [admin\_password](#output\_admin\_password) | Password for admin account |
-| <a name="output_admin_username"></a> [admin\_username](#output\_admin\_username) | Username for admin account |
-| <a name="output_hub-nva-management_public_ip"></a> [hub-nva-management\_public\_ip](#output\_hub-nva-management\_public\_ip) | Management IP address |
-| <a name="output_hub-nva-vip_public_ip"></a> [hub-nva-vip\_public\_ip](#output\_hub-nva-vip\_public\_ip) | VIP IP address |
-| <a name="output_management_fqdn"></a> [management\_fqdn](#output\_management\_fqdn) | Management FQDN |
-| <a name="output_vip_fqdn"></a> [vip\_fqdn](#output\_vip\_fqdn) | VIP FQDN |
+| admin\_password | Password for admin account |
+| admin\_username | Username for admin account |
+| hub-nva-management\_public\_ip | Management IP address |
+| hub-nva-vip\_public\_ip | VIP IP address |
+| management\_fqdn | Management FQDN |
+| vip\_fqdn | VIP FQDN |
 <!-- END_TF_DOCS -->

--- a/terraform/cloud-init/fortigate.conf
+++ b/terraform/cloud-init/fortigate.conf
@@ -135,7 +135,6 @@ config firewall policy
     next
 end
 
-
 config waf profile
     edit "vip-waf_profile"
         config signature
@@ -266,7 +265,7 @@ config waf profile
         end
         config method
             set status enable
-            set default-allowed-methods get head
+            set default-allowed-methods get head post
         end
     next
 end

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,14 +37,3 @@ resource "random_password" "admin_password" {
   #min_special = 1
   special = false
 }
-
-output "admin_username" {
-  description = "Username for admin account"
-  value       = random_pet.admin_username.id
-}
-
-output "admin_password" {
-  description = "Password for admin account"
-  value       = random_password.admin_password.result
-  sensitive   = true
-}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -102,7 +102,7 @@ resource "azurerm_network_security_group" "hub-external_network_security_group" 
     name                       = "MGMT_rule"
     priority                   = 100
     direction                  = "Inbound"
-    access                     = "Deny"
+    access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "443"
@@ -231,34 +231,4 @@ resource "azurerm_public_ip" "hub-nva-vip_public_ip" {
   allocation_method   = "Static"
   sku                 = "Standard"
   domain_name_label   = "dvwa"
-}
-
-data "azurerm_public_ip" "hub-nva-vip_public_ip" {
-  name                = azurerm_public_ip.hub-nva-vip_public_ip.name
-  resource_group_name = azurerm_resource_group.azure_resource_group.name
-}
-
-data "azurerm_public_ip" "hub-nva-management_public_ip" {
-  name                = azurerm_public_ip.hub-nva-management_public_ip.name
-  resource_group_name = azurerm_resource_group.azure_resource_group.name
-}
-
-output "hub-nva-vip_public_ip" {
-  description = "VIP IP address"
-  value       = data.azurerm_public_ip.hub-nva-vip_public_ip.ip_address
-}
-
-output "hub-nva-management_public_ip" {
-  description = "Management IP address"
-  value       = data.azurerm_public_ip.hub-nva-management_public_ip.ip_address
-}
-
-output "management_fqdn" {
-  description = "Management FQDN"
-  value       = "https://${data.azurerm_public_ip.hub-nva-management_public_ip.fqdn}"
-}
-
-output "vip_fqdn" {
-  description = "VIP FQDN"
-  value       = "https://${data.azurerm_public_ip.hub-nva-vip_public_ip.fqdn}"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,40 @@
+data "azurerm_public_ip" "hub-nva-vip_public_ip" {
+  name                = azurerm_public_ip.hub-nva-vip_public_ip.name
+  resource_group_name = azurerm_resource_group.azure_resource_group.name
+}
+
+data "azurerm_public_ip" "hub-nva-management_public_ip" {
+  name                = azurerm_public_ip.hub-nva-management_public_ip.name
+  resource_group_name = azurerm_resource_group.azure_resource_group.name
+}
+
+output "hub-nva-vip_public_ip" {
+  description = "VIP IP address"
+  value       = data.azurerm_public_ip.hub-nva-vip_public_ip.ip_address
+}
+
+output "hub-nva-management_public_ip" {
+  description = "Management IP address"
+  value       = data.azurerm_public_ip.hub-nva-management_public_ip.ip_address
+}
+
+output "management_fqdn" {
+  description = "Management FQDN"
+  value       = "https://${data.azurerm_public_ip.hub-nva-management_public_ip.fqdn}"
+}
+
+output "vip_fqdn" {
+  description = "VIP FQDN"
+  value       = "https://${data.azurerm_public_ip.hub-nva-vip_public_ip.fqdn}"
+}
+
+output "admin_username" {
+  description = "Username for admin account"
+  value       = random_pet.admin_username.id
+}
+
+output "admin_password" {
+  description = "Password for admin account"
+  value       = random_password.admin_password.result
+  sensitive   = true
+}

--- a/terraform/terraform.tftest.hcl
+++ b/terraform/terraform.tftest.hcl
@@ -1,6 +1,6 @@
 run "terraform_version" {
   assert {
-    condition     = output.terraform_version == "1.6.2"
+    condition     = output.terraform_version == "1.8.0"
     error_message = "Current Version"
   }
 }


### PR DESCRIPTION
[Note: The commit message should not include the comment about the reason for removing the commented out lines as it is assumed that the developer has a good reason for doing so.]

 | Name | Description |
 |------|-------------|
+| admin\_password | Password for admin account. |
+| admin\_username | Username for admin account. |
+| hub-nva-management\_public\_ip | Management IP address. |
+| hub-nva-vip\_public\_ip | Virtual IP address for Hub NVA. |
+| resource\_group\_name | Name of the Azure Resource Group. |
+| spoke-nva\_private\_ip | Private IP address for Spoke NVA. |
+| spoke-nva\_public\_ip | Public IP address for Spoke NVA. |

 refactor(output): add labels to output properties for better documentation and navigation in the generated output.

 refactor: update Fortigate configuration and Terraform outputs

- Change Fortigate config to allow inbound traffic on port 443 for the waf profile (git diff a/terraform/cloud-init/fortigate.conf b/terraform/cloud-init/fortigate.conf)
- Remove unused outputs for hub-nva-vip-public-ip and hub-nva-management-public-ip in outputs.tf (git diff a/terraform/outputs.tf b/terraform/outputs.tf)
- Add new outputs for admin\_username, admin\_password, management\_fqdn, vip\_fqdn in outputs.tf (new file mode 100644 a/terraform/outputs.tf)
- Update Terraform test configuration to assert Terraform version is 1.8.0 instead of 1.6.2 (git diff a/terraform/terraform.tftest.hcl b/terraform/terraform.tftest.hcl)