### PR TITLE
disable TLS for ollama api

### DIFF
--- a/terraform/cloud-init/fortigate.conf
+++ b/terraform/cloud-init/fortigate.conf
@@ -257,7 +257,7 @@ config firewall vip
     next
     edit "virtual-server-ollama"
         set type server-load-balance
-        set server-type https
+        set server-type http
         set extip ${VAR-hub-nva-vip}
         set extintf "port1"
         set extport ${VAR-spoke-container-server-ollama-port}
@@ -268,7 +268,6 @@ config firewall vip
                 set port ${VAR-spoke-container-server-ollama-port} 
             next
         end
-        set ssl-certificate Fortinet_SSL_RSA2048
     next
 end
 


### PR DESCRIPTION
Disables TLS for the Ollama API by changing the server-type from https to http in the Fortigate configuration file. Additionally, it removes the SSL certificate setting for the virtual server.
By making these changes, we are intentionally removing the TLS encryption for the Ollama API, which may be necessary for certain development or testing scenarios where security measures can be relaxed.
This modification allows for easier communication with the Ollama API without the overhead of TLS encryption, catering to specific use cases that do not require secure communication.
This change provides flexibility in testing and development environments while acknowledging the potential security implications of disabling TLS for the Ollama API.