### PR TITLE
adding outputs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -50,7 +50,7 @@ spoke-check-internet-up-ip           = "8.8.8.8"
 | azurerm | 3.104.2 |
 | http | 3.4.1 |
 | null | 3.2.2 |
-| random | 3.6.1 |
+| random | 3.6.2 |
 | tls | 4.0.5 |
 
 ## Inputs
@@ -83,6 +83,7 @@ spoke-check-internet-up-ip           = "8.8.8.8"
 
 | Name | Description |
 |------|-------------|
+| OLLAMA\_HOST | OLLAMA\_HOST URI |
 | admin\_password | Password for admin account |
 | admin\_username | Username for admin account |
 | management\_fqdn | Management FQDN |

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -19,6 +19,11 @@ output "vip_fqdn" {
   value       = "https://${data.azurerm_public_ip.hub-nva-vip_public_ip.fqdn}"
 }
 
+output "OLLAMA_HOST" {
+  description = "OLLAMA_HOST URI"
+  value       = "export OLLAMA_HOST=http://${data.azurerm_public_ip.hub-nva-vip_public_ip.fqdn}:11434"
+}
+
 output "admin_username" {
   description = "Username for admin account"
   value       = random_pet.admin_username.id


### PR DESCRIPTION
Adds a new output named `OLLAMA_HOST` to the Terraform configuration. The `OLLAMA_HOST` output provides the URI for the OLLAMA_HOST, and its value is set to `http://${data.azurerm_public_ip.hub-nva-vip_public_ip.fqdn}:11434`.

By including this output, users of the Terraform configuration will have access to the OLLAMA_HOST URI, which can be useful for various purposes within the project. This enhancement improves the usability and flexibility of the Terraform setup by exposing this important information to users.