### PR TITLE
terraform-docs: automated action

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -100,7 +100,6 @@ spoke-check-internet-up-ip           = "8.8.8.8"
 | OLLAMA\_HOST | OLLAMA\_HOST URI |
 | admin\_password | Password for admin account |
 | admin\_username | Username for admin account |
-| kube\_config | n/a |
 | management\_fqdn | Management FQDN |
 | registry\_admin\_password | n/a |
 | registry\_admin\_username | n/a |


### PR DESCRIPTION
Automates the process of updating the Terraform documentation by removing the outdated `kube_config` variable from the `README.md` file. This change ensures that the documentation accurately reflects the current state of the project and eliminates any confusion for users.

By keeping the documentation up-to-date, we provide clear and reliable information for users, making it easier for them to understand and work with our Terraform configuration. This automated action streamlines the documentation maintenance process and helps maintain consistency across the project.