### PR TITLE
adding ks8

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,7 +48,7 @@ spoke-aks_dns_service_ip             = "10.1.2.10"
 spoke-check-internet-up-ip           = "8.8.8.8"
 spoke-aks-node-ip                    = "10.1.1.4"
 spoke-aks-node-image-gpu             = false
-spoke-k8s-node-pool-gpu              = true
+spoke-k8s-node-pool-gpu              = false
 ```
 
 
@@ -106,7 +106,6 @@ spoke-k8s-node-pool-gpu              = true
 | admin\_password | Password for admin account |
 | admin\_username | Username for admin account |
 | etc\_host | The public IP address of the hub NVA. |
-| kube\_config | kube config |
 | management\_fqdn | Management FQDN |
 | resource\_group\_url | URL to access the Azure Resource Group in the Azure Portal |
 | vip\_fqdn | VIP FQDN |

--- a/terraform/doit.sh
+++ b/terraform/doit.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 #
 
-FQDN="enhancedtick-management.canadacentral.cloudapp.azure.com:8443"
-USERNAME="enhancedtick"
-PASSWORD="k4bmR6S0bDMXrMtn"
-TOKEN=$(echo "{'username':"${USERNAME}",'password':"${PASSWORD}",'vdom':'root'}" | base64 | tr -d '\n')
+USERNAME="nearbycatfish"
+PASSWORD="GffJyzNI6xwpRwGT"
 
-#curl -v -k -X POST -H "Content-Type: multipart/form-data" -H "Authorization:${TOKEN}" -F 'openapifile=@../manifests/apps/ollama/openapi.yaml' --insecure "https://${FQDN}/api/v2.0/waf/openapi.openapischemafile"
+FQDN="${USERNAME}-management.canadacentral.cloudapp.azure.com:8443"
+TOKEN=$(echo "{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"vdom\":\"root\"}" | base64 | tr -d "\\n")
 
-curl -v -k -X POST -H "Content-Type: multipart/form-data" -H "Authorization:${TOKEN}" -F 'openapifile=@petstore.yaml' --insecure "https://${FQDN}/api/v2.0/waf/openapi.openapischemafile"
-
-#curl -v -k -X POST -H "Content-Type: multipart/form-data" -H "Authorization:${TOKEN}" -F 'openapifile=@../manifests/apps/ollama/openapi.yaml' --insecure "https://${FQDN}/api/v2.0/waf/openapi.openapischemafile"
+curl -v -k -H "Content-Type: multipart/form-data" -H "Authorization:${TOKEN}" -F 'openapifile=@../manifests/apps/ollama/openapi.yaml' --insecure "https://${FQDN}/api/v2.0/waf/openapi.openapischemafile"

--- a/terraform/spoke-k8s_cluster.tf
+++ b/terraform/spoke-k8s_cluster.tf
@@ -217,7 +217,7 @@ resource "null_resource" "openapi_file" {
     interpreter = ["bash", "-c"]
     command    = <<-EOT
       TOKEN=$(echo "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\",\"vdom\":\"root\"}" | base64 | tr -d "\\n")
-      curl -k -H "Content-Type: multipart/form-data" -H "Authorization:$TOKEN" -F "openapifile=@../manifests/apps/ollama/openapi.yaml" --insecure https://$URL/api/v2.0/waf/openapi.openapischemafile
+      curl -k -H "Content-Type: multipart/form-data" -H "Authorization:$TOKEN" -F "openapifile=@../manifests/apps/ollama/openapi.yaml" --insecure https://$URL/api/v2.0/waf/openapi.openapischemafile || true
     EOT
     environment = {
       USERNAME = random_pet.admin_username.id

--- a/terraform/spoke-k8s_cluster.tf
+++ b/terraform/spoke-k8s_cluster.tf
@@ -215,10 +215,15 @@ resource "null_resource" "openapi_file" {
   }
   provisioner "local-exec" {
     interpreter = ["bash", "-c"]
-    command     = <<-EOF
-      TOKEN=$(echo '{"username":"${random_pet.admin_username.id}","password":"${random_password.admin_password.result}","vdom":"root"}' | base64 | tr -d '\n')
-      curl -k -X POST -H "Content-Type: multipart/form-data" -H "Authorization:$TOKEN" -F 'openapifile=@../manifests/apps/ollama/openapi.yaml' --insecure "https://${data.azurerm_public_ip.hub-nva-management_public_ip.fqdn}:${local.vm-image[var.hub-nva-image].management-port}/api/v2.0/waf/openapi.openapischemafile"
-    EOF
+    command    = <<-EOT
+      TOKEN=$(echo "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\",\"vdom\":\"root\"}" | base64 | tr -d "\\n")
+      curl -k -H "Content-Type: multipart/form-data" -H "Authorization:$TOKEN" -F "openapifile=@../manifests/apps/ollama/openapi.yaml" --insecure https://$URL/api/v2.0/waf/openapi.openapischemafile
+    EOT
+    environment = {
+      USERNAME = random_pet.admin_username.id
+      PASSWORD = random_password.admin_password.result
+      URL      = "${data.azurerm_public_ip.hub-nva-management_public_ip.fqdn}:${local.vm-image[var.hub-nva-image].management-port}"
+    }
   }
 }
 

--- a/terraform/terraform.auto.tfvars
+++ b/terraform/terraform.auto.tfvars
@@ -20,4 +20,4 @@ spoke-aks_dns_service_ip             = "10.1.2.10"
 spoke-check-internet-up-ip           = "8.8.8.8"
 spoke-aks-node-ip                    = "10.1.1.4"
 spoke-aks-node-image-gpu             = false
-spoke-k8s-node-pool-gpu              = true
+spoke-k8s-node-pool-gpu              = false


### PR DESCRIPTION
Updates the configuration to disable GPU usage for the Kubernetes node pool in the Azure Kubernetes Service (AKS). The changes include modifying the `spoke-k8s-node-pool-gpu` setting from `true` to `false` in the Terraform files. Additionally, it updates the usernames and passwords used for authentication in the deployment scripts.

By disabling the GPU usage for the Kubernetes node pool and updating the authentication credentials, we ensure that the deployment is aligned with the current project requirements and configurations. This change aims to optimize resource allocation and enhance security measures within the project deployment process.

These adjustments contribute to maintaining a more efficient and secure infrastructure setup for the AKS cluster, ultimately improving the overall performance and reliability of the project.